### PR TITLE
Address a breaking change in the config tree building

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,10 +28,10 @@ class Configuration implements ConfigurationInterface
 	 */
 	public function getConfigTreeBuilder()
 	{
-		$treeBuilder = new TreeBuilder();
-		$rootNode = $treeBuilder->root( 'aimeos_shop' );
+		$treeBuilder = new TreeBuilder( 'aimeos_shop' );
 
-		$rootNode
+		$treeBuilder
+			->getRootNode()
 			->children()
 				->booleanNode( 'disable_sites' )->defaultValue( true )->end()
 				->booleanNode( 'apc_enable' )->defaultValue( false )->end()


### PR DESCRIPTION
The configuration TreeBuilder construction has changed and not passing the root node name to the constructor is deprecated: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L30 . It's actually broken in Symfony 5+.

Note that this commit breaks compatibility with Symfony 3.4 to 4.1 (which are not supported anymore).